### PR TITLE
Fixing an issue with bundle install and the Kibana config file

### DIFF
--- a/logstash_server
+++ b/logstash_server
@@ -41,10 +41,10 @@ popd
 pushd /opt/
 git clone --branch=kibana-ruby https://github.com/rashidkpc/Kibana.git
 pushd Kibana
-sed -i 's#KibanaHost =.*#KibanaHost = 0.0.0.0#' KibanaConfig.rb
+sed -i 's#KibanaHost =.*#KibanaHost = "0.0.0.0"#' KibanaConfig.rb
 sed -i 's#KibanaPort =.*#KibanaPort = 80#' KibanaConfig.rb
 gem install bundler
-bundle installvm
+bundle install
 cp $ROOT/init/kibana.conf /etc/init/kibana.conf
 service kibana start
 popd


### PR DESCRIPTION
This fixes an issue with the bundle command and the Kibana config

```
/opt/Kibana$ sudo ruby kibana.rb
/usr/lib/ruby/vendor_ruby/1.8/rubygems/custom_require.rb:36:in `gem_original_require': /opt/Kibana/KibanaConfig.rb:16: no .<digit> floating literal anymore; put 0 before dot (SyntaxError)
  KibanaHost = 0.0.0.0
                   ^
/opt/Kibana/KibanaConfig.rb:16: syntax error, unexpected tFLOAT
        from /usr/lib/ruby/vendor_ruby/1.8/rubygems/custom_require.rb:36:in `require'
        from /opt/Kibana/lib/kibana.rb:4
        from /usr/lib/ruby/vendor_ruby/1.8/rubygems/custom_require.rb:36:in `gem_original_require'
        from /usr/lib/ruby/vendor_ruby/1.8/rubygems/custom_require.rb:36:in `require'
        from kibana.rb:4

/opt/Kibana$ bundle installvm
Could not find task "installvm".
```
